### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: c
+
+env:
+  - AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_NO_UI=1
+
+script:
+  - make
+  - ./afl-gcc ./test-instr.c -o test-instr
+  - mkdir seeds; mkdir out
+  - echo "" > seeds/nil_seed
+  - timeout --preserve-status 5s ./afl-fuzz -i seeds -o out/ -- ./test-instr

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # american fuzzy lop
 
+[![Build Status](https://travis-ci.org/google/AFL.svg?branch=master)](https://travis-ci.org//google/AFL)
+
 Originally developed by Michal Zalewski <lcamtuf@google.com>.
 
 See [QuickStartGuide.txt](QuickStartGuide.txt) if you don't have time to read


### PR DESCRIPTION
Let's make sure no one accidentally breaks master.

Just a basic test for now, runs the test-instr.c binary for 5 seconds. In the future this should be expanded to test persistent mode etc.