### PR TITLE
Make it possible to compile AFL with `-std=c11 and -D_GNU_SOURCE`

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -31,7 +31,9 @@
 #define AFL_MAIN
 #define MESSAGES_TO_STDOUT
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #define _FILE_OFFSET_BITS 64
 
 #include "config.h"

--- a/types.h
+++ b/types.h
@@ -86,7 +86,7 @@ typedef int64_t  s64;
 #define STRINGIFY(x) STRINGIFY_INTERNAL(x)
 
 #define MEM_BARRIER() \
-  asm volatile("" ::: "memory")
+  __asm__ volatile("" ::: "memory")
 
 #define likely(_x)   __builtin_expect(!!(_x), 1)
 #define unlikely(_x)  __builtin_expect(!!(_x), 0)


### PR DESCRIPTION
This will eliminate our need to patch AFL in Chromium.

`__asm__` is the standard way to do what `asm` does, `asm` is a gnuism that won't work with -std=c11.