### PR TITLE
Fix compilation errors for QEMU mode for recent glibc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,18 @@ language: c
 env:
   - AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_NO_UI=1
 
+before_install:
+  - sudo apt update
+  - sudo apt install -y libtool libtool-bin automake bison libglib2.0
+
 script:
   - make
   - ./afl-gcc ./test-instr.c -o test-instr
   - mkdir seeds; mkdir out
   - echo "" > seeds/nil_seed
   - timeout --preserve-status 5s ./afl-fuzz -i seeds -o out/ -- ./test-instr
+  - cd qemu_mode
+  - ./build_qemu_support.sh
+  - cd ..
+  - gcc ./test-instr.c -o test-no-instr
+  - timeout --preserve-status 5s ./afl-fuzz -Q -i seeds -o out/ -- ./test-no-instr

--- a/qemu_mode/build_qemu_support.sh
+++ b/qemu_mode/build_qemu_support.sh
@@ -137,6 +137,8 @@ echo "[*] Applying patches..."
 patch -p1 <../patches/elfload.diff || exit 1
 patch -p1 <../patches/cpu-exec.diff || exit 1
 patch -p1 <../patches/syscall.diff || exit 1
+patch -p1 <../patches/configure.diff || exit 1
+patch -p1 <../patches/memfd.diff || exit 1
 
 echo "[+] Patching done."
 

--- a/qemu_mode/patches/configure.diff
+++ b/qemu_mode/patches/configure.diff
@@ -1,0 +1,11 @@
+--- qemu-2.10.0-clean/configure	2019-08-01 23:04:12.511396481 +0200
++++ qemu-2.10.0/configure	2019-08-01 23:04:32.936429232 +0200
+@@ -3855,7 +3855,7 @@
+ # check if memfd is supported
+ memfd=no
+ cat > $TMPC << EOF
+-#include <sys/memfd.h>
++#include <sys/mman.h>
+ 
+ int main(void)
+ {

--- a/qemu_mode/patches/memfd.diff
+++ b/qemu_mode/patches/memfd.diff
@@ -1,0 +1,13 @@
+--- qemu-2.10.0-clean/util/memfd.c	2019-08-01 23:04:12.562396563 +0200
++++ qemu-2.10.0/util/memfd.c	2019-08-01 23:06:47.882646792 +0200
+@@ -31,9 +31,7 @@
+ 
+ #include "qemu/memfd.h"
+ 
+-#ifdef CONFIG_MEMFD
+-#include <sys/memfd.h>
+-#elif defined CONFIG_LINUX
++#if defined CONFIG_LINUX && !defined CONFIG_MEMFD
+ #include <sys/syscall.h>
+ #include <asm/unistd.h>
+ 


### PR DESCRIPTION
As explained in QEMU git commit 75e5b70e6b5dcc4f2219992d7cffa462aa406af0 (https://git.qemu.org/?p=qemu.git;a=commitdiff;h=75e5b70e6b5dcc4f2219992d7cffa462aa406af0), recent versions of the glibc add memfd_create, which creates conflicts at compile time for QEMU 2.10.

This can be fixed by adding a pair of patches when building QEMU with AFL support.