### PR TITLE
Adding statistic metrics: peak_rss_mb and slowest_exec_ms

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -2421,7 +2421,7 @@ static u8 run_target(char** argv, u32 timeout) {
   }
 
   if (!WIFSTOPPED(status)) child_pid = 0;
-  
+
   getitimer (ITIMER_REAL, &it);
   exec_ms = (u64) timeout - (it.it_value.tv_sec * 1000 + it.it_value.tv_usec / 1000);
   if (slowest_exec_ms < exec_ms){

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -8094,6 +8094,12 @@ int main(int argc, char** argv) {
 
   if (queue_cur) show_stats();
 
+  /* if we stopped programmatically, we kill the forkserver and the current runner. 
+     if we stopped manually, this is done by the signal handler */
+  if (stop_soon == 2){
+      if (child_pid > 0) kill(child_pid, SIGKILL);
+      if (forksrv_pid > 0) kill(forksrv_pid, SIGKILL);
+  }
   /* Now that we've killed the forkserver, we wait for it to be able to get rusage stats. */
   if( waitpid(forksrv_pid, NULL, 0) <= 0 ) {
     WARNF("error waitpid\n");

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -181,6 +181,7 @@ EXP_ST u64 total_crashes,             /* Total number of crashes          */
            unique_tmouts,             /* Timeouts with unique signatures  */
            unique_hangs,              /* Hangs with unique signatures     */
            total_execs,               /* Total execve() calls             */
+           slowest_exec_ms,           /* Slowest testcase non hang in ms  */
            start_time,                /* Unix start time (ms)             */
            last_path_time,            /* Time for most recent path (ms)   */
            last_crash_time,           /* Time for most recent crash (ms)  */
@@ -2272,6 +2273,7 @@ static u8 run_target(char** argv, u32 timeout) {
 
   static struct itimerval it;
   static u32 prev_timed_out = 0;
+  static u64 exec_ms = 0;
 
   int status = 0;
   u32 tb4;
@@ -2419,6 +2421,12 @@ static u8 run_target(char** argv, u32 timeout) {
   }
 
   if (!WIFSTOPPED(status)) child_pid = 0;
+  
+  getitimer (ITIMER_REAL, &it);
+  exec_ms = (u64) timeout - (it.it_value.tv_sec * 1000 + it.it_value.tv_usec / 1000);
+  if (slowest_exec_ms < exec_ms){
+    slowest_exec_ms = exec_ms;
+  }
 
   it.it_value.tv_sec = 0;
   it.it_value.tv_usec = 0;
@@ -3441,7 +3449,8 @@ static void write_stats_file(double bitmap_cvg, double stability, double eps) {
              "afl_banner        : %s\n"
              "afl_version       : " VERSION "\n"
              "target_mode       : %s%s%s%s%s%s%s\n"
-             "command_line      : %s\n",
+             "command_line      : %s\n"
+             "slowest_exec_ms   : %llu\n",
              start_time / 1000, get_cur_time() / 1000, getpid(),
              queue_cycle ? (queue_cycle - 1) : 0, total_execs, eps,
              queued_paths, queued_favored, queued_discovered, queued_imported,
@@ -3455,7 +3464,7 @@ static void write_stats_file(double bitmap_cvg, double stability, double eps) {
              persistent_mode ? "persistent " : "", deferred_mode ? "deferred " : "",
              (qemu_mode || dumb_mode || no_forkserver || crash_mode ||
               persistent_mode || deferred_mode) ? "" : "default",
-             orig_cmdline);
+             orig_cmdline, slowest_exec_ms);
              /* ignore errors */
 
   /* Get rss value from the children


### PR DESCRIPTION
Gather more metrics and print them in the fuzzer_stats report to better understand how a fuzzer behaves:

- **peak_rss_mb**: the maximum rss value reached during the fuzzing. This is collected by the parent process at the end of the fuzzing session using `getrusage` on `RUSAGE_CHILDREN` (the parent process needs to end and wait for the children to use the `RUSAGE_CHILDREN` option).
- **slowest_exec_ms**: duration of the slowest execution in ms that is not considered as a hang. 