### PR TITLE
work around segfault bug with clang custom passes

### DIFF
--- a/llvm_mode/Makefile
+++ b/llvm_mode/Makefile
@@ -36,7 +36,8 @@ CXXFLAGS    ?= -O3 -funroll-loops
 CXXFLAGS    += -Wall -D_FORTIFY_SOURCE=2 -g -Wno-pointer-sign \
                -DVERSION=\"$(VERSION)\" -Wno-variadic-macros
 
-CLANG_CFL    = `$(LLVM_CONFIG) --cxxflags` -fno-rtti -fpic $(CXXFLAGS)
+# Mark nodelete to work around unload bug in upstream LLVM 5.0+
+CLANG_CFL    = `$(LLVM_CONFIG) --cxxflags` -Wl,-znodelete -fno-rtti -fpic $(CXXFLAGS)
 CLANG_LFL    = `$(LLVM_CONFIG) --ldflags` $(LDFLAGS)
 
 # User teor2345 reports that this is required to make things work on MacOS X.


### PR DESCRIPTION
When shutting down LLVM, the custom pass shared library can be prematurely unloaded, resulting in a dangling pointer. As a workaround, instruct the linker to mark the custom pass not to be unloaded at runtime.

References:
https://groups.google.com/forum/#!msg/afl-users/TDLrTu3V_Pw/K4svutarAAAJ
https://stackoverflow.com/questions/47712670/segmentation-fault-in-llvm-pass-when-using-registerstandardpasses
https://github.com/sampsyo/llvm-pass-skeleton/issues/7

Upstream bugs:
https://bugs.llvm.org/show_bug.cgi?id=34573
https://bugs.llvm.org/show_bug.cgi?id=39321
https://bugs.llvm.org/show_bug.cgi?id=36183