### PR TITLE
run the afl-clang-fast instrumentation much earlier

### DIFF
--- a/llvm_mode/afl-llvm-pass.so.cc
+++ b/llvm_mode/afl-llvm-pass.so.cc
@@ -186,7 +186,7 @@ static void registerAFLPass(const PassManagerBuilder &,
 
 
 static RegisterStandardPasses RegisterAFLPass(
-    PassManagerBuilder::EP_OptimizerLast, registerAFLPass);
+    PassManagerBuilder::EP_ModuleOptimizerEarly, registerAFLPass);
 
 static RegisterStandardPasses RegisterAFLPass0(
     PassManagerBuilder::EP_EnabledOnOptLevel0, registerAFLPass);


### PR DESCRIPTION
As of current trunk LLVM, the instrumentation no longer functions correctly because the IR may have already been simplified to remove explicit branches. For example, on this snippet of the sample test-instr.c file:

```if (buf[0] == '0')```

Clang 10.0.0 (trunk 370425) (llvm/trunk 370432) produces the following IR:

```
%cmp2 = icmp eq i8 %19, 48, !dbg !36
%.sink = select i1 %cmp2, i8* getelementptr inbounds ([26 x i8], [26 x i8]* @.str.1, i64 0, i64 0), i8* getelementptr inbounds ([31 x i8], [31 x i8]* @.str.2, i64 0, i64 0), !dbg !37
%call6 = tail call i32 (i32, i8*, ...) @__printf_chk(i32 1, i8* %.sink) #6, !dbg !38
```

Previously, Clang 8.0.0-3~ubuntu18.04.1 (tags/RELEASE_800/final) produced the following IR:

```
%29 = icmp eq i8 %28, 48, !dbg !37
br i1 %29, label %30, label %38, !dbg !38
```

As a workaround, run the instrumentation earlier, likely before e.g. the 'simplifycfg' pass removes explicit branches.