### PR TITLE
Bump AFL version for the next release

### DIFF
--- a/config.h
+++ b/config.h
@@ -28,7 +28,7 @@
 
 /* Version string: */
 
-#define VERSION             "2.54b"
+#define VERSION             "2.56b"
 
 /******************************************************
  *                                                    *


### PR DESCRIPTION
It skips `v2.55b` version because tag [`v2.55b`](https://github.com/google/AFL/releases/tag/v2.55b) was created for `v2.54b` afl-fuzz version (mind blown gif). So, for avoiding any possible conflicts (for example with [homebrew's version of AFL](https://github.com/Homebrew/homebrew-core/pull/44421/files)) I bumped it with a gap.
