### PR TITLE
qemu_mode: redesign for increased performance

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -7646,10 +7646,6 @@ static char** get_qemu_argv(u8* own_loc, char** argv, int argc) {
   char** new_argv = ck_alloc(sizeof(char*) * (argc + 4));
   u8 *tmp, *cp, *rsl, *own_copy;
 
-  /* Workaround for a QEMU stability glitch. */
-
-  setenv("QEMU_LOG", "nochain", 1);
-
   memcpy(new_argv + 3, argv + 1, sizeof(char*) * argc);
 
   new_argv[2] = target_path;

--- a/qemu_mode/build_qemu_support.sh
+++ b/qemu_mode/build_qemu_support.sh
@@ -139,6 +139,8 @@ patch -p1 <../patches/cpu-exec.diff || exit 1
 patch -p1 <../patches/syscall.diff || exit 1
 patch -p1 <../patches/configure.diff || exit 1
 patch -p1 <../patches/memfd.diff || exit 1
+patch -p1 <../patches/gen-icount.diff || exit 1
+patch -p1 <../patches/tcg-runtime.diff || exit 1
 
 echo "[+] Patching done."
 

--- a/qemu_mode/patches/afl-qemu-inst.h
+++ b/qemu_mode/patches/afl-qemu-inst.h
@@ -1,0 +1,37 @@
+#include "../../config.h"
+
+#define AFL_QEMU_INST_SNIPPET do { \
+    afl_maybe_instrument(tb); \
+  } while(0)
+
+extern abi_ulong afl_start_code, afl_end_code;
+extern unsigned int afl_inst_rms;
+
+/* Decide whether it is appropriate to instrument a TranslationBlock
+   and if so, generate a call to the helper tcg_log in the current
+   tcg_ctx */
+
+static void afl_maybe_instrument(TranslationBlock *tb) {
+    if (tb->pc < afl_end_code && tb->pc >= afl_start_code) {
+        /* Looks like QEMU always maps to fixed locations, so ASAN is not a
+           concern. Phew. But instruction addresses may be aligned. Let's
+           mangle the value to get something quasi-uniform. */
+        abi_ulong loc_hash = (tb->pc >> 4) ^ (tb->pc << 8);
+        loc_hash &= MAP_SIZE - 1;
+
+        /* Implement probabilistic instrumentation by looking at loc_hash.
+           This keeps the instrumented locations stable across runs.*/
+        if (loc_hash < afl_inst_rms) {
+            /* It would be possible to make the helper function discover its
+               own virtual pc address at runtime but that would require us
+               to mark the helper as "reads global state", causing tcg to
+               spill its registers before each call. Instead we pre-calculate
+               the hashed "location" value for each site and pass it as an
+               argument through an immediate. */
+            TCGv_i32 loc_imm = tcg_temp_new_i32();
+            /* 32bit MAP_SIZE ought to be enough for anybody */
+            tcg_gen_movi_i32(loc_imm, (uint32_t) loc_hash);
+            gen_helper_afl_log(loc_imm);
+        }
+    }
+}

--- a/qemu_mode/patches/cpu-exec.diff
+++ b/qemu_mode/patches/cpu-exec.diff
@@ -13,7 +13,7 @@
      int tb_exit;
      uint8_t *tb_ptr = itb->tc_ptr;
  
-+    AFL_QEMU_CPU_SNIPPET2;
++    AFL_QEMU_FORK_SNIPPET;
 +
      qemu_log_mask_and_addr(CPU_LOG_EXEC, itb->pc,
                             "Trace %p [%d: " TARGET_FMT_lx "] %s\n",
@@ -22,7 +22,15 @@
              if (!tb) {
                  /* if no translated code available, then translate it now */
                  tb = tb_gen_code(cpu, pc, cs_base, flags, 0);
-+                AFL_QEMU_CPU_SNIPPET1;
++                AFL_QEMU_TSL_SNIPPET;
              }
  
              mmap_unlock();
+@@ -627,6 +632,8 @@
+     int ret;
+     SyncClocks sc = { 0 };
+ 
++    AFL_QEMU_SETUP_SNIPPET;
++
+     /* replay_interrupt may need current_cpu */
+     current_cpu = cpu;

--- a/qemu_mode/patches/gen-icount.diff
+++ b/qemu_mode/patches/gen-icount.diff
@@ -1,0 +1,20 @@
+--- qemu-2.10.0-clean/include/exec/gen-icount.h
++++ qemu-2.10.0/include/exec/gen-icount.h
+@@ -3,6 +3,8 @@
+ 
+ #include "qemu/timer.h"
+ 
++#include "../patches/afl-qemu-inst.h"
++
+ /* Helpers for instruction counting code generation.  */
+ 
+ static int icount_start_insn_idx;
+@@ -10,6 +12,8 @@ static TCGLabel *exitreq_label;
+ 
+ static inline void gen_tb_start(TranslationBlock *tb)
+ {
++    AFL_QEMU_INST_SNIPPET;
++
+     TCGv_i32 count, imm;
+ 
+     exitreq_label = gen_new_label();

--- a/qemu_mode/patches/tcg-runtime.diff
+++ b/qemu_mode/patches/tcg-runtime.diff
@@ -1,0 +1,33 @@
+--- qemu-2.10.0-clean/tcg/tcg-runtime.h
++++ qemu-2.10.0/tcg/tcg-runtime.h
+@@ -24,6 +24,8 @@ DEF_HELPER_FLAGS_1(clrsb_i64, TCG_CALL_NO_RWG_SE, i64, i64)
+ DEF_HELPER_FLAGS_1(ctpop_i32, TCG_CALL_NO_RWG_SE, i32, i32)
+ DEF_HELPER_FLAGS_1(ctpop_i64, TCG_CALL_NO_RWG_SE, i64, i64)
+ 
++DEF_HELPER_FLAGS_1(afl_log, TCG_CALL_NO_RWG, void, i32)
++
+ DEF_HELPER_FLAGS_2(lookup_tb_ptr, TCG_CALL_NO_WG_SE, ptr, env, tl)
+ 
+ DEF_HELPER_FLAGS_1(exit_atomic, TCG_CALL_NO_WG, noreturn, env)
+
+--- qemu-2.10.0-clean/tcg/tcg-runtime.c
++++ qemu-2.10.0/tcg/tcg-runtime.c
+@@ -31,6 +31,18 @@
+ #include "disas/disas.h"
+ #include "exec/log.h"
+ 
++extern char *afl_area_ptr;
++
++void HELPER(afl_log)(uint32_t cur_loc)
++{
++    static __thread uint32_t prev_loc;
++
++    if (afl_area_ptr) {
++        afl_area_ptr[cur_loc ^ prev_loc]++;
++        prev_loc = cur_loc >> 1;
++    }
++}
++
+ /* 32-bit helpers */
+ 
+ int32_t HELPER(div_i32)(int32_t arg1, int32_t arg2)


### PR DESCRIPTION
Instead of requiring qemu to return to its outer emulation loop for every `TranslationBlock`'s execution and deciding whether to record each execution at runtime, decide whether to instrument each TB with a call to a TCG "helper function" at IR generation time.

This means we can remove the qemu `nochain` option, re-enabling block chaining, one of TCG's most important performance features. Without block chaining, qemu has to spill all its registers, look up the next TB and then re-pack registers for every basic block it comes across, both in uninteresting/library code and in interesting/executable code.

This results in a 3-4x speedup for my use case. I'd love for people to have a go and see how it works for them.

(I suspect there is probably also room for a more aggressive mode which forwards `last_tb` information down the "translation request" pipeline, allowing the already-chained blocks to be pre-generated by the forkserver too, though I think this is not guaranteed safe for all cases which e.g. modify executable areas or use `dlopen` to load code at runtime)