### PR TITLE
Fix counting stage execs for user inserts

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -5980,7 +5980,7 @@ skip_interest:
   stage_name  = "user extras (insert)";
   stage_short = "ext_UI";
   stage_cur   = 0;
-  stage_max   = extras_cnt * len;
+  stage_max   = extras_cnt * (len + 1);
 
   orig_hit_cnt = new_hit_cnt;
 


### PR DESCRIPTION
Pretty obvious, because of the number of iterations of the outer loop few lines later:

`for (i = 0; i <= len; i++) {`

Without the fix the progress can (and does for me) go over 100% otherwise.