### PR TITLE
Add option -V: Show version number and exit

### DIFF
--- a/afl-analyze.c
+++ b/afl-analyze.c
@@ -822,6 +822,10 @@ static void usage(u8* argv0) {
 
        "  -e            - look for edge coverage only, ignore hit counts\n\n"
 
+       "Other stuff:\n\n"
+
+       "  -V            - show version number and exit\n\n"
+
        "For additional tips, please consult %s/README.\n\n",
 
        argv0, EXEC_TIMEOUT, MEM_LIMIT, doc_path);
@@ -959,7 +963,7 @@ int main(int argc, char** argv) {
 
   SAYF(cCYA "afl-analyze " cBRI VERSION cRST " by <lcamtuf@google.com>\n");
 
-  while ((opt = getopt(argc,argv,"+i:f:m:t:eQ")) > 0)
+  while ((opt = getopt(argc,argv,"+i:f:m:t:eQV")) > 0)
 
     switch (opt) {
 
@@ -1038,6 +1042,11 @@ int main(int argc, char** argv) {
 
         qemu_mode = 1;
         break;
+
+      case 'V': /* Show version number */
+
+        /* Version number has been printed already, just quit. */
+        exit(0);
 
       default:
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -7107,7 +7107,8 @@ static void usage(u8* argv0) {
 
        "  -T text       - text banner to show on the screen\n"
        "  -M / -S id    - distributed mode (see parallel_fuzzing.txt)\n"
-       "  -C            - crash exploration mode (the peruvian rabbit thing)\n\n"
+       "  -C            - crash exploration mode (the peruvian rabbit thing)\n"
+       "  -V            - show version number and exit\n\n"
 
        "For additional tips, please consult %s/README.\n\n",
 
@@ -7764,7 +7765,7 @@ int main(int argc, char** argv) {
   gettimeofday(&tv, &tz);
   srandom(tv.tv_sec ^ tv.tv_usec ^ getpid());
 
-  while ((opt = getopt(argc, argv, "+i:o:f:m:t:T:dnCB:S:M:x:Q")) > 0)
+  while ((opt = getopt(argc, argv, "+i:o:f:m:t:T:dnCB:S:M:x:QV")) > 0)
 
     switch (opt) {
 
@@ -7931,6 +7932,11 @@ int main(int argc, char** argv) {
         if (!mem_limit_given) mem_limit = MEM_LIMIT_QEMU;
 
         break;
+
+      case 'V': /* Show version number */
+
+        /* Version number has been printed already, just quit. */
+        exit(0);
 
       default:
 

--- a/afl-showmap.c
+++ b/afl-showmap.c
@@ -495,7 +495,8 @@ static void usage(u8* argv0) {
 
        "  -q            - sink program's output and don't show messages\n"
        "  -e            - show edge coverage only, ignore hit counts\n"
-       "  -c            - allow core dumps\n\n"
+       "  -c            - allow core dumps\n"
+       "  -V            - show version number and exit\n\n"
 
        "This tool displays raw tuple data captured by AFL instrumentation.\n"
        "For additional help, consult %s/README.\n\n" cRST,
@@ -634,7 +635,7 @@ int main(int argc, char** argv) {
 
   doc_path = access(DOC_PATH, F_OK) ? "docs" : DOC_PATH;
 
-  while ((opt = getopt(argc,argv,"+o:m:t:A:eqZQbc")) > 0)
+  while ((opt = getopt(argc,argv,"+o:m:t:A:eqZQbcV")) > 0)
 
     switch (opt) {
 
@@ -744,6 +745,11 @@ int main(int argc, char** argv) {
         if (keep_cores) FATAL("Multiple -c options not supported");
         keep_cores = 1;
         break;
+
+      case 'V':
+
+        show_banner();
+        exit(0);
 
       default:
 

--- a/afl-tmin.c
+++ b/afl-tmin.c
@@ -833,6 +833,10 @@ static void usage(u8* argv0) {
        "  -e            - solve for edge coverage only, ignore hit counts\n"
        "  -x            - treat non-zero exit codes as crashes\n\n"
 
+       "Other stuff:\n\n"
+
+       "  -V            - show version number and exit\n\n"
+
        "For additional tips, please consult %s/README.\n\n",
 
        argv0, EXEC_TIMEOUT, MEM_LIMIT, doc_path);
@@ -986,7 +990,7 @@ int main(int argc, char** argv) {
 
   SAYF(cCYA "afl-tmin " cBRI VERSION cRST " by <lcamtuf@google.com>\n");
 
-  while ((opt = getopt(argc,argv,"+i:o:f:m:t:B:xeQ")) > 0)
+  while ((opt = getopt(argc,argv,"+i:o:f:m:t:B:xeQV")) > 0)
 
     switch (opt) {
 
@@ -1097,6 +1101,11 @@ int main(int argc, char** argv) {
         mask_bitmap = ck_alloc(MAP_SIZE);
         read_bitmap(optarg);
         break;
+
+      case 'V': /* Show version number */
+
+        /* Version number has been printed already, just quit. */
+        exit(0);
 
       default:
 


### PR DESCRIPTION
Adds command line option -V to afl-analyze, afl-fuzz, afl-showmap, and afl-tmin to show the current AFL version number and terminate.