### PR TITLE
afl-clang-fast: remove useless codes related to maybe_linking

### DIFF
--- a/llvm_mode/afl-clang-fast.c
+++ b/llvm_mode/afl-clang-fast.c
@@ -103,7 +103,7 @@ static void find_obj(u8* argv0) {
 
 static void edit_params(u32 argc, char** argv) {
 
-  u8 fortify_set = 0, asan_set = 0, x_set = 0, maybe_linking = 1, bit_mode = 0;
+  u8 fortify_set = 0, asan_set = 0, x_set = 0, bit_mode = 0;
   u8 *name;
 
   cc_params = ck_alloc((argc + 128) * sizeof(u8*));
@@ -141,10 +141,6 @@ static void edit_params(u32 argc, char** argv) {
 
   cc_params[cc_par_cnt++] = "-Qunused-arguments";
 
-  /* Detect stray -v calls from ./configure scripts. */
-
-  if (argc == 1 && !strcmp(argv[1], "-v")) maybe_linking = 0;
-
   while (--argc) {
     u8* cur = *(++argv);
 
@@ -154,15 +150,10 @@ static void edit_params(u32 argc, char** argv) {
 
     if (!strcmp(cur, "-x")) x_set = 1;
 
-    if (!strcmp(cur, "-c") || !strcmp(cur, "-S") || !strcmp(cur, "-E"))
-      maybe_linking = 0;
-
     if (!strcmp(cur, "-fsanitize=address") ||
         !strcmp(cur, "-fsanitize=memory")) asan_set = 1;
 
     if (strstr(cur, "FORTIFY_SOURCE")) fortify_set = 1;
-
-    if (!strcmp(cur, "-shared")) maybe_linking = 0;
 
     if (!strcmp(cur, "-Wl,-z,defs") ||
         !strcmp(cur, "-Wl,--no-undefined")) continue;


### PR DESCRIPTION
Now that the maybe_linking check is removed in afl-clang-fast.c, maybe it is better to remove useless codes caused by it since maybe_linking is now defined but not used.

I think in the old code, "maybe_linking" should not be set to zero on seeing the "-shared" argument because dynamic libraries should also statically link the AFL runtime into themselves. But now that the maybe_linking variable is removed, it is no more a problem.

Besides, the code 'if (argc == 1 && !strcmp(argv[1], "-v")) maybe_linking = 0;' in line 146 itself is useless regardless of the maybe_linking variable because in main() we have check "if argc < 2, then exit".