### PR TITLE
[Question] Using a static seed for repeatable fuzzing results

### DIFF
--- a/config.h
+++ b/config.h
@@ -28,7 +28,7 @@
 
 /* Version string: */
 
-#define VERSION             "2.56b"
+#define VERSION             "2.56b+static-seed"
 
 /******************************************************
  *                                                    *

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -17,6 +17,22 @@ is 2.41b. If you're stuck on an earlier release, it's strongly advisable
 to get on with the times.
 
 ---------------------------
+Version 2.56b (2019-09-26):
+---------------------------
+
+  - Fixed the mismatch between the released version and the version in the code.
+
+---------------------------
+Version 2.55b (2019-09-19):
+---------------------------
+
+  - Exporting more metrics (peak_rss_mb, slowest_exec_ms).
+
+  - Improved tests.
+
+  - Fixes for bugs and changes in upstream llvm/clang.
+
+---------------------------
 Version 2.54b (2019-08-27):
 ---------------------------
 

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -16,6 +16,14 @@ Not sure if you should upgrade? The lowest currently recommended version
 is 2.41b. If you're stuck on an earlier release, it's strongly advisable
 to get on with the times.
 
+
+---------------------------
+Version 2.56b+static-seed (2020-04-07):
+---------------------------
+
+  - Add `-D` param to make fuzzing results repeatable by passing a static
+    seed (and thus forcing deterministic randomness)
+
 ---------------------------
 Version 2.56b (2019-09-26):
 ---------------------------


### PR DESCRIPTION
Hi!

This not a serious pull request, but a question you may have an answer to.

I'm currently writing a paper in which I'm trying to find out if it makes sense to run AFL in a Kubernetes cluster.
In order to do this, I'm doing a performance comparison between running AFL in Kubernetes and running AFL in a virtual machine. The metrics I use are `execs_done` and `unique_crashes` from the `fuzzer_stats` file.

Here's the problem: since AFL relies on randomness for mutations, the results I'm getting will be influenced by this randomness, which I want to avoid. (I want deterministic/repeatable fuzzing results.)

My solution to this "problem" was to introduce a static-seed CLI option. This option will stop the reseeding process via `/dev/urandom` and only initialize the RNG once with `srandom()` at the start of AFL. (See code change in this PR.)

So my question is: does this make sense to you? Am I missing something?

Thanks for your input!