### PR TITLE
fix negative stability bug

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -2556,7 +2556,7 @@ static u8 calibrate_case(char** argv, struct queue_entry* q, u8* use_mem,
 
   static u8 first_trace[MAP_SIZE];
 
-  u8  fault = 0, new_bits = 0, var_detected = 0,
+  u8  fault = 0, new_bits = 0, var_detected = 0, hnb = 0,
       first_run = (q->exec_cksum == 0);
 
   u64 start_us, stop_us;
@@ -2584,7 +2584,13 @@ static u8 calibrate_case(char** argv, struct queue_entry* q, u8* use_mem,
   if (dumb_mode != 1 && !no_forkserver && !forksrv_pid)
     init_forkserver(argv);
 
-  if (q->exec_cksum) memcpy(first_trace, trace_bits, MAP_SIZE);
+  if (q->exec_cksum) {
+
+    memcpy(first_trace, trace_bits, MAP_SIZE);
+    hnb = has_new_bits(virgin_bits);
+    if (hnb > new_bits) new_bits = hnb;
+
+  }
 
   start_us = get_cur_time_us();
 
@@ -2612,7 +2618,7 @@ static u8 calibrate_case(char** argv, struct queue_entry* q, u8* use_mem,
 
     if (q->exec_cksum != cksum) {
 
-      u8 hnb = has_new_bits(virgin_bits);
+      hnb = has_new_bits(virgin_bits);
       if (hnb > new_bits) new_bits = hnb;
 
       if (q->exec_cksum) {


### PR DESCRIPTION
Since 2017 there was a bug in afl that resulted in a negative stability being displayed in the UI.
Problematic is that is usually only happens in highly volatile targets after running for > 24h, so finding and fixing it was a long and tedious task.

source of the issue is that first_trace is used to compare against repeated runs of new queue entries, but the contents of first_trace was not added to the discovered bits.

This PR fixes the negative stability UI bug.