### PR TITLE
experimental/argv_fuzzing: fixed argv parsing

### DIFF
--- a/experimental/argv_fuzzing/test.c
+++ b/experimental/argv_fuzzing/test.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include "argv-fuzz-inl.h"
+
+int main(int argc, char *argv[]) {
+	AFL_INIT_SET0("a.out");
+
+	int i;
+	printf("argc = %d\n", argc);
+	for (i = 0; i < argc; i++)
+		printf("argv[%d] = '%s'\n", i, argv[i]);
+	return 0;
+}

--- a/experimental/argv_fuzzing/test.txt
+++ b/experimental/argv_fuzzing/test.txt
@@ -1,0 +1,1 @@
+param1 -t  param3 --param=val param5


### PR DESCRIPTION
AFAIK, argv-parsing was somewhat broken. All I could get was argv[0] or argv[1] with the full line of input (e.g. all parameters with spaces as argv[0]). We should fix this or at least propose working test file for exising implementation.