### PR TITLE
Install README.md instead of pointless empty README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ endif
 	set -e; for i in afl-g++ afl-clang afl-clang++; do ln -sf afl-gcc $${DESTDIR}$(BIN_PATH)/$$i; done
 	install -m 755 afl-as $${DESTDIR}$(HELPER_PATH)
 	ln -sf afl-as $${DESTDIR}$(HELPER_PATH)/as
-	install -m 644 docs/README docs/ChangeLog docs/*.txt $${DESTDIR}$(DOC_PATH)
+	install -m 644 README.md docs/ChangeLog docs/*.txt $${DESTDIR}$(DOC_PATH)
 	cp -r testcases/ $${DESTDIR}$(MISC_PATH)
 	cp -r dictionaries/ $${DESTDIR}$(MISC_PATH)
 


### PR DESCRIPTION
The Makefile of afl installs an empty README file to the doc dir. This is obviously pointless.

This PR changes this to install the README.md instead and removes the empty README file.