### PR TITLE
Fix next_100 pointers

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -825,7 +825,7 @@ static void add_to_queue(u8* fname, u32 len, u8 passed_det) {
   cycles_wo_finds = 0;
 
   /* Set next_100 pointer for every 100th element (index 0, 100, etc) to allow faster iteration. */
-  if (queued_paths % 100 == 1 && queued_paths > 1) {
+  if ((queued_paths - 1) % 100 == 0 && queued_paths > 1) {
 
     q_prev100->next_100 = q;
     q_prev100 = q;

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -824,7 +824,7 @@ static void add_to_queue(u8* fname, u32 len, u8 passed_det) {
 
   cycles_wo_finds = 0;
 
-  if (queued_paths > 1 && queued_paths % 100 == 1) {
+  if (queued_paths % 100 == 1 && queued_paths > 1) {
 
     q_prev100->next_100 = q;
     q_prev100 = q;

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -824,7 +824,7 @@ static void add_to_queue(u8* fname, u32 len, u8 passed_det) {
 
   cycles_wo_finds = 0;
 
-  if (queued_paths - 1 && queued_paths % 100 == 1) {
+  if (queued_paths > 1 && queued_paths % 100 == 1) {
 
     q_prev100->next_100 = q;
     q_prev100 = q;

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -824,6 +824,13 @@ static void add_to_queue(u8* fname, u32 len, u8 passed_det) {
 
   cycles_wo_finds = 0;
 
+  /* we set here next_100 pointer on every new entry
+   * which index is multiple of 100 and positive
+   * to get faster entry with corresponding big index (>=100)
+   * in splicing stage
+   *
+   * note that while index is 100 (e.g.), queued_paths is 101
+   */
   if (queued_paths % 100 == 1 && queued_paths > 1) {
 
     q_prev100->next_100 = q;

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -824,13 +824,7 @@ static void add_to_queue(u8* fname, u32 len, u8 passed_det) {
 
   cycles_wo_finds = 0;
 
-  /* we set here next_100 pointer on every new entry
-   * which index is multiple of 100 and positive
-   * to get faster entry with corresponding big index (>=100)
-   * in splicing stage
-   *
-   * note that while index is 100 (e.g.), queued_paths is 101
-   */
+  /* Set next_100 pointer for every 100th element (index 0, 100, etc) to allow faster iteration. */
   if (queued_paths % 100 == 1 && queued_paths > 1) {
 
     q_prev100->next_100 = q;

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -824,7 +824,7 @@ static void add_to_queue(u8* fname, u32 len, u8 passed_det) {
 
   cycles_wo_finds = 0;
 
-  if (!(queued_paths % 100)) {
+  if (queued_paths - 1 && queued_paths % 100 == 1) {
 
     q_prev100->next_100 = q;
     q_prev100 = q;


### PR DESCRIPTION
The current realization (master branch) of `next_100` pointers update slightly constrain splicing stage if we have 101+ entries in queue. More precisely, the last entry in queue will never be chosen as second entry to splice with. For example, in queue contained 101, 102, 103, ..., 200, 201 etc. entries the last entry will always be skipped.

Let's consider the reason.
Let queue with `queued_paths = n` consists of n entries with indices 0..n-1
When queued_paths is 100 we set `next_100` pointer to refer on the last element of queue with index = 99 here:
```
if (!(queued_paths % 100)) {

    q_prev100->next_100 = q;
    q_prev100 = q;

}
```

Consider queue contains 101 entries with indices 0..100.
In splicing stage after this line call, where the random index from 0..100 can be chosen:
`
do { tid = UR(queued_paths); } while (tid == current_entry);
`

suppose tid is 100. So, we expect to take the entry with index = 100

But, in this line:
`
while (tid >= 100) { target = target->next_100; tid -= 100; }
`

the expression `target = target->next_100` give us entry with index = 99.
