### PR TITLE
Print all dependencies at once in install script instead of one at a time.

### DIFF
--- a/qemu_mode/build_qemu_support.sh
+++ b/qemu_mode/build_qemu_support.sh
@@ -62,6 +62,8 @@ if [ ! -f "../afl-showmap" ]; then
 fi
 
 
+DEPENDENCY_ERR=false
+
 for i in libtool wget python automake autoconf sha384sum bison iconv; do
 
   T=`which "$i" 2>/dev/null`
@@ -69,7 +71,7 @@ for i in libtool wget python automake autoconf sha384sum bison iconv; do
   if [ "$T" = "" ]; then
 
     echo "[-] Error: '$i' not found, please install first."
-    exit 1
+    DEPENDENCY_ERR=true
 
   fi
 
@@ -78,16 +80,23 @@ done
 if [ ! -d "/usr/include/glib-2.0/" -a ! -d "/usr/local/include/glib-2.0/" ]; then
 
   echo "[-] Error: devel version of 'glib2' not found, please install first."
-  exit 1
+  DEPENDENCY_ERR=true
+
+fi
+
+if [ "$DEPENDENCY_ERR" = true ]; then
+
+    echo "[-] Error: dependencies missing. Please install them and try again!"
+    exit 1
 
 fi
 
 if echo "$CC" | grep -qF /afl-; then
 
   echo "[-] Error: do not use afl-gcc or afl-clang to compile this tool."
-  exit 1
 
 fi
+
 
 echo "[+] All checks passed!"
 


### PR DESCRIPTION
I've installed AFL a few times in the last couple days and have been mildly annoyed by the fact that there is an `exit 1` in the qemu build script after each failed dependency. In practice, this means that I (a person who forgot the dependencies) need to run the script several times and install dependencies each time until I have them all. This is a super small patch, but it fixes the issue and just gives you the full list of missing dependencies. I just tested on a fresh Ubuntu 20.04 docker:

```sh
root@1c3eaa577e21:/AFL/qemu_mode# ./build_qemu_support.sh 
=================================================
AFL binary-only instrumentation QEMU build script
=================================================

[*] Performing basic sanity checks...
[-] Error: 'libtool' not found, please install first.
[-] Error: 'wget' not found, please install first.
[-] Error: 'python' not found, please install first.
[-] Error: 'automake' not found, please install first.
[-] Error: 'autoconf' not found, please install first.
[-] Error: 'bison' not found, please install first.
[-] Error: devel version of 'glib2' not found, please install first.
[-] Error: dependencies missing. Please install them and try again!
root@1c3eaa577e21:/AFL/qemu_mode# apt-get install libtool-bin wget python automake autoconf bison libglib2.0-dev
```

Hopefully this 5 minute fix makes life a little easier for folks :)
