### PR TITLE
afl-clang-fast: modify edit_params() to handle '-r/--relocatable' parameters for partial linking

### DIFF
--- a/llvm_mode/afl-clang-fast.c
+++ b/llvm_mode/afl-clang-fast.c
@@ -103,7 +103,7 @@ static void find_obj(u8* argv0) {
 
 static void edit_params(u32 argc, char** argv) {
 
-  u8 fortify_set = 0, asan_set = 0, x_set = 0, bit_mode = 0;
+  u8 fortify_set = 0, asan_set = 0, x_set = 0, bit_mode = 0, partial_linking = 0;
   u8 *name;
 
   cc_params = ck_alloc((argc + 128) * sizeof(u8*));
@@ -147,6 +147,9 @@ static void edit_params(u32 argc, char** argv) {
     if (!strcmp(cur, "-m32")) bit_mode = 32;
     if (!strcmp(cur, "armv7a-linux-androideabi")) bit_mode = 32;
     if (!strcmp(cur, "-m64")) bit_mode = 64;
+
+    if (!strcmp(cur, "-r") ||
+        !strcmp(cur, "--relocatable")) partial_linking = 1;
 
     if (!strcmp(cur, "-x")) x_set = 1;
 
@@ -277,31 +280,33 @@ static void edit_params(u32 argc, char** argv) {
     cc_params[cc_par_cnt++] = "none";
   }
 
+  if (!partial_linking) {
 #ifndef __ANDROID__
-  switch (bit_mode) {
+    switch (bit_mode) {
 
-    case 0:
-      cc_params[cc_par_cnt++] = alloc_printf("%s/afl-llvm-rt.o", obj_path);
-      break;
+      case 0:
+        cc_params[cc_par_cnt++] = alloc_printf("%s/afl-llvm-rt.o", obj_path);
+        break;
 
-    case 32:
-      cc_params[cc_par_cnt++] = alloc_printf("%s/afl-llvm-rt-32.o", obj_path);
+      case 32:
+        cc_params[cc_par_cnt++] = alloc_printf("%s/afl-llvm-rt-32.o", obj_path);
 
-      if (access(cc_params[cc_par_cnt - 1], R_OK))
-        FATAL("-m32 is not supported by your compiler");
+        if (access(cc_params[cc_par_cnt - 1], R_OK))
+          FATAL("-m32 is not supported by your compiler");
 
-      break;
+        break;
 
-    case 64:
-      cc_params[cc_par_cnt++] = alloc_printf("%s/afl-llvm-rt-64.o", obj_path);
+      case 64:
+        cc_params[cc_par_cnt++] = alloc_printf("%s/afl-llvm-rt-64.o", obj_path);
 
-      if (access(cc_params[cc_par_cnt - 1], R_OK))
-        FATAL("-m64 is not supported by your compiler");
+        if (access(cc_params[cc_par_cnt - 1], R_OK))
+          FATAL("-m64 is not supported by your compiler");
 
-      break;
+        break;
 
-  }
+    }
 #endif
+  }
 
   cc_params[cc_par_cnt] = NULL;
 


### PR DESCRIPTION
There is a case that AFL cannot compile busybox. It is because the
building system of busybox uses the partial linking feature of ld
while the afl-clang-fast cannot handle such case.

More specifically, the building system of busybox first merges several
relocatable object file into a new relocatable file using the '-r'
option, where the afl-llvm-rt.o added by afl-clang-fast is also merged,
so the new relocatable file contains the symbols from afl-llvm-rt.o.
At the final linking step, the new relocatable file is linked with
afl-llvm-rt.o (added again by afl-clang-fast) into the executable file,
but both files contain the definitions of the symbols from afl-llvm-rt.o.
As a result, the compiler complains that and stop the building process.

I fix this by restraining afl-clang-fast from adding the 'afl-llvm-rt.o'
parameter when seeing the '-r/--relocatable' parameter in the cmd line.